### PR TITLE
tensorflow only use amount of memory needed

### DIFF
--- a/calamari_ocr/ocr/backends/tensorflow_backend/tensorflow_model.py
+++ b/calamari_ocr/ocr/backends/tensorflow_backend/tensorflow_model.py
@@ -2,7 +2,15 @@ import tensorflow as tf
 import numpy as np
 import json
 from typing import Generator
-
+gpus = tf.config.experimental.list_physical_devices('GPU')
+if gpus:
+  try:
+    # Currently, memory growth needs to be the same across GPUs
+    for gpu in gpus:
+      tf.config.experimental.set_memory_growth(gpu, True)
+  except RuntimeError as e:
+    # Memory growth must be set before GPUs have been initialized
+    print(e)
 
 from calamari_ocr.ocr.backends.model_interface import ModelInterface, NetworkPredictionResult
 from calamari_ocr.ocr.callbacks import TrainingCallback


### PR DESCRIPTION
limit GPU memory usage, so cross-fold-train can have max_parallel_models > 1 on a single GPU
based on this tensorflow guide page:
https://www.tensorflow.org/guide/gpu#limiting_gpu_memory_growth
Code has to be executed prior to allocating any tensors or executing any ops.
So, I put the code at the top of calamari_ocr/ocr/backends/tensorflow_backend/tensorflow_model.py
I tested it with max_parallel_models=4, seemed to work.
